### PR TITLE
Remove UL list type circle for docked blocks menu items

### DIFF
--- a/style/blocks.css
+++ b/style/blocks.css
@@ -128,3 +128,9 @@
 .block_adminblock .content .singleselect {
     text-align: left;
 }
+
+/* Docked block
+------------------------------*/
+.block_tree.list ul,li{
+    list-style-type: none;
+}  


### PR DESCRIPTION
When a docked block is being viewed, it contains extra
circle bullet points. This removes those circle bullet points
by adding list-style-type:none at blocks.css for
.block_tree.list ul,li selector.