### PR TITLE
Remove duplicate sectionname

### DIFF
--- a/style/course.css
+++ b/style/course.css
@@ -19,7 +19,7 @@
 }
 
 .path-course-view .section .content {
-    padding: 10px;
+    padding: 0;
 }
 
 .path-course-view .section .content .section {
@@ -114,4 +114,8 @@
 
 #page-course-publish-backup .sharecoursecontinue {
     text-align: center;
+}
+
+.hidden.sectionname {
+    visibility: hidden;
 }


### PR DESCRIPTION
The section name in course page is duplicated. One should
be remove. This fixes the CSS to remove that.

![screenshot_2017-09-17_15-42-36](https://user-images.githubusercontent.com/16247613/30518545-2e6d8b7a-9bc0-11e7-87b2-80ffb3b45f0a.png)
