### PR TITLE
theme_canvas: Remove list type circle for docked blocks

### DIFF
--- a/style/blocks.css
+++ b/style/blocks.css
@@ -128,3 +128,9 @@
 .block_adminblock .content .singleselect {
     text-align: left;
 }
+
+/* Docked block
+------------------------------*/
+.block_tree.list ul,li{
+    list-style-type: none;
+}

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2016052300; // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2017091800; // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2016051900; // Requires this Moodle version
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->component = 'theme_canvas'; // Full name of the plugin (used for diagnostics)


### PR DESCRIPTION
When a docked block is being viewed, it contains extra
circle bullet points. This removes those circle bullet points
by adding list-style-type:none at blocks.css for
.block_tree.list ul,li selector.
![29255343-f11b0414-808f-11e7-9f92-48d1a8d297ac](https://user-images.githubusercontent.com/16247613/30531736-55a6fd5a-9c8f-11e7-88b7-33946c0f5d95.png)



This does not happen in its parent theme 'theme_base' as dock blocks is not available for theme_base.
![screenshot_2017-09-18_08-03-08](https://user-images.githubusercontent.com/16247613/30531708-2985a0be-9c8f-11e7-95fd-b18882fcfeb6.png)
